### PR TITLE
Add na_rm param to crosstabs

### DIFF
--- a/R/create_polling_crosstabs.R
+++ b/R/create_polling_crosstabs.R
@@ -110,6 +110,7 @@ create_polling_crosstabs <- function(
   row_vars,
   subgroup_vars,
   wt_var,
+  na_rm = TRUE,
   min_n = 75,
   file_name,
   sheet_name,

--- a/R/create_polling_crosstabs.R
+++ b/R/create_polling_crosstabs.R
@@ -97,7 +97,7 @@ calc_moe <- function(p, n, deff) {
 #'   subgroup_vars = c("gender", "race"),
 #'   wt_var = "weight",
 #'   min_n = 75,
-#'   na_rm = TRUE
+#'   na_rm = TRUE,
 #'   file_name = "crosstabs.xlsx",
 #'   sheet_name = "Results",
 #'   summary_string = "January 2026 National Poll",

--- a/R/create_polling_crosstabs.R
+++ b/R/create_polling_crosstabs.R
@@ -76,6 +76,7 @@ calc_moe <- function(p, n, deff) {
 #'   object, in which case weights are taken from the design.
 #' @param min_n Integer specifying minimum unweighted sample size for a subgroup
 #'   to be included (default: 75)
+#' @param na_rm Logical; whether to remove rows with missing values in x and group before computing frequencies. Default is TRUE.
 #' @param file_name Character string specifying the Excel file path/name
 #' @param sheet_name Character string specifying the sheet name
 #' @param overwrite_existing_sheet Logical indicating whether to overwrite existing
@@ -96,9 +97,10 @@ calc_moe <- function(p, n, deff) {
 #'   subgroup_vars = c("gender", "race"),
 #'   wt_var = "weight",
 #'   min_n = 75,
+#'   na_rm = TRUE
 #'   file_name = "crosstabs.xlsx",
 #'   sheet_name = "Results",
-#'   summary_string = "January 2026 National Poll"
+#'   summary_string = "January 2026 National Poll",
 #' )
 #' }
 #'
@@ -267,14 +269,14 @@ create_polling_crosstabs <- function(
         get_freqs(
           data = col_data,
           x = tidyselect::all_of(var),
-          na.rm = TRUE
+          na.rm = na_rm
         )
       } else {
         get_freqs(
           data = col_data,
           x = tidyselect::all_of(var),
           wt = !!rlang::sym(wt_var),
-          na.rm = TRUE
+          na.rm = na_rm
         )
       }
 

--- a/man/create_polling_crosstabs.Rd
+++ b/man/create_polling_crosstabs.Rd
@@ -39,6 +39,8 @@ sheet with same name (default: TRUE)}
 
 \item{summary_string}{Character string to display in the top-left merged cell
 (default: "")}
+
+\item{na_rm}{Logical; whether to remove rows with missing values in x and group before computing frequencies. Default is TRUE.}
 }
 \value{
 Data frame with columns: subgroup_var, subgroup_var_label, subgroup_val,
@@ -64,9 +66,10 @@ results <- create_polling_crosstabs(
   subgroup_vars = c("gender", "race"),
   wt_var = "weight",
   min_n = 75,
+  na_rm = TRUE
   file_name = "crosstabs.xlsx",
   sheet_name = "Results",
-  summary_string = "January 2026 National Poll"
+  summary_string = "January 2026 National Poll",
 )
 }
 

--- a/man/create_polling_crosstabs.Rd
+++ b/man/create_polling_crosstabs.Rd
@@ -9,6 +9,7 @@ create_polling_crosstabs(
   row_vars,
   subgroup_vars,
   wt_var,
+  na_rm = TRUE,
   min_n = 75,
   file_name,
   sheet_name,
@@ -27,6 +28,8 @@ create_polling_crosstabs(
 Ignored when \code{data} is a \code{survey.design} or \code{svyrep.design}
 object, in which case weights are taken from the design.}
 
+\item{na_rm}{Logical; whether to remove rows with missing values in x and group before computing frequencies. Default is TRUE.}
+
 \item{min_n}{Integer specifying minimum unweighted sample size for a subgroup
 to be included (default: 75)}
 
@@ -39,8 +42,6 @@ sheet with same name (default: TRUE)}
 
 \item{summary_string}{Character string to display in the top-left merged cell
 (default: "")}
-
-\item{na_rm}{Logical; whether to remove rows with missing values in x and group before computing frequencies. Default is TRUE.}
 }
 \value{
 Data frame with columns: subgroup_var, subgroup_var_label, subgroup_val,
@@ -66,7 +67,7 @@ results <- create_polling_crosstabs(
   subgroup_vars = c("gender", "race"),
   wt_var = "weight",
   min_n = 75,
-  na_rm = TRUE
+  na_rm = TRUE,
   file_name = "crosstabs.xlsx",
   sheet_name = "Results",
   summary_string = "January 2026 National Poll",


### PR DESCRIPTION
This updates the polling crosstabs function to have a `na_rm` parameter that allows the user to include NAs in the denominator of calculations using `get_freqs()`